### PR TITLE
fix: include dist folder in npm package

### DIFF
--- a/.changeset/dull-mugs-make.md
+++ b/.changeset/dull-mugs-make.md
@@ -1,0 +1,5 @@
+---
+"i18n-po-sheet-sync": patch
+---
+
+fix: include dist folder in npm package

--- a/package.json
+++ b/package.json
@@ -11,6 +11,13 @@
       "require": "./dist/index.js"
     }
   },
+  "files": [
+    "dist",
+    "README.md",
+    "README-ko_kr.md",
+    "LICENSE",
+    "package.json"
+  ],
   "scripts": {
     "export": "node -r @swc-node/register example/export-to-po.ts",
     "upload": "node -r @swc-node/register example/upload-to-po.ts",


### PR DESCRIPTION
- Add "files" field to package.json to explicitly include dist directory
- Ensure built files are properly distributed with npm package
- Fix missing dist folder in published package